### PR TITLE
Extend parameterset

### DIFF
--- a/R/AutoxgbResult.R
+++ b/R/AutoxgbResult.R
@@ -23,10 +23,12 @@ print.AutoxgbResult = function(x, ...) {
   catf("Autoxgboost tuning result\n")
   catf("Recommended parameters:")
   for (p in names(pars)) {
-    if (p != "nrounds" && isNumeric(op$par.set$pars[[p]], include.int = FALSE)) {
+    if (p == "nrounds" || isInteger(op$par.set$pars[[p]])) {
+      catf("%s: %i", stringi::stri_pad_left(p, width = 17), as.integer(pars[p]))
+    } else if (isNumeric(op$par.set$pars[[p]], include.int = FALSE)) {
       catf("%s: %.3f", stringi::stri_pad_left(p, width = 17), pars[p])
     } else {
-      catf("%s: %i", stringi::stri_pad_left(p, width = 17), as.integer(pars[p]))
+      catf("%s: %s", stringi::stri_pad_left(p, width = 17), pars[p])
     }
   }
 

--- a/R/RLearner_classif_xgboost.custom.R
+++ b/R/RLearner_classif_xgboost.custom.R
@@ -4,8 +4,6 @@ makeRLearner.classif.xgboost.custom = function() {
     cl = "classif.xgboost.custom",
     package = "xgboost",
     par.set = makeParamSet(
-      # we pass all of what goes in 'params' directly to ... of xgboost
-      # makeUntypedLearnerParam(id = "params", default = list()),
       makeDiscreteLearnerParam(id = "booster", default = "gbtree", values = c("gbtree", "gblinear", "dart")),
       makeUntypedLearnerParam(id = "watchlist", default = NULL, tunable = FALSE),
       makeNumericLearnerParam(id = "eta", default = 0.3, lower = 0, upper = 1),
@@ -29,7 +27,6 @@ makeRLearner.classif.xgboost.custom = function() {
       makeNumericLearnerParam(id = "tweedie_variance_power", lower = 1, upper = 2, default = 1.5, requires = quote(objective == "reg:tweedie")),
       makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE),
       makeIntegerLearnerParam(id = "nrounds", default = 1L, lower = 1L),
-      # FIXME nrounds seems to have no default in xgboost(), if it has 1, par.vals is redundant
       makeUntypedLearnerParam(id = "feval", default = NULL, tunable = FALSE),
       makeIntegerLearnerParam(id = "verbose", default = 1L, lower = 0L, upper = 2L, tunable = FALSE),
       makeIntegerLearnerParam(id = "print_every_n", default = 1L, lower = 1L, tunable = FALSE,

--- a/R/RLearner_classif_xgboost.earlystop.R
+++ b/R/RLearner_classif_xgboost.earlystop.R
@@ -21,6 +21,7 @@ makeRLearner.classif.xgboost.earlystop = function() {
       makeIntegerLearnerParam(id = "early_stopping_rounds", default = 1, lower = 1L, tunable = FALSE),
       makeIntegerLearnerParam(id = "max.nrounds", default = 10^6L, lower = 1L, upper = 10^7L),
       makeUntypedLearnerParam(id = "early.stopping.data"),
+      makeLogicalLearnerParam(id = "maximize", default = NULL, special.vals = list(NULL), tunable = FALSE),
       makeNumericLearnerParam(id = "scale_pos_weight", lower = 0),
       makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE)
     ),

--- a/R/RLearner_classif_xgboost.earlystop.R
+++ b/R/RLearner_classif_xgboost.earlystop.R
@@ -23,7 +23,17 @@ makeRLearner.classif.xgboost.earlystop = function() {
       makeUntypedLearnerParam(id = "early.stopping.data"),
       makeLogicalLearnerParam(id = "maximize", default = NULL, special.vals = list(NULL), tunable = FALSE),
       makeNumericLearnerParam(id = "scale_pos_weight", lower = 0),
-      makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE)
+      makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE),
+      makeDiscreteLearnerParam(id = "booster", default = "gbtree", values = c("gbtree", "gblinear", "dart")),
+      makeDiscreteLearnerParam(id = "sample_type", default = "uniform", values = c("uniform", "weighted"), requires = quote(booster == "dart")),
+      makeDiscreteLearnerParam(id = "normalize_type", default = "tree", values = c("tree", "forest"), requires = quote(booster == "dart")),
+      makeNumericLearnerParam(id = "rate_drop", default = 0, lower = 0, upper = 1, requires = quote(booster == "dart")),
+      makeNumericLearnerParam(id = "skip_drop", default = 0, lower = 0, upper = 1, requires = quote(booster == "dart")),
+      makeLogicalLearnerParam(id = "one_drop", default = FALSE, requires = quote(booster == "dart")),
+      makeDiscreteLearnerParam(id = "tree_method", default = "exact", values = c("exact", "hist"), requires = quote(booster != "gblinear")),
+      makeDiscreteLearnerParam(id = "grow_policy", default = "depthwise", values = c("depthwise", "lossguide"), requires = quote(tree_method == "hist")),
+      makeIntegerLearnerParam(id = "max_leaves", default = 0L, lower = 0L, requires = quote(grow_policy == "lossguide")),
+      makeIntegerLearnerParam(id = "max_bin", default = 256L, lower = 2L, requires = quote(tree_method == "hist"))
     ),
     properties = c("twoclass", "multiclass", "numerics", "prob", "weights", "missings"),
     name = "eXtreme Gradient Boosting",

--- a/R/RLearner_regr_xgboost.custom.R
+++ b/R/RLearner_regr_xgboost.custom.R
@@ -4,8 +4,6 @@ makeRLearner.regr.xgboost.custom = function() {
     cl = "regr.xgboost.custom",
     package = "xgboost",
     par.set = makeParamSet(
-      # we pass all of what goes in 'params' directly to ... of xgboost
-      #makeUntypedLearnerParam(id = "params", default = list()),
       makeDiscreteLearnerParam(id = "booster", default = "gbtree", values = c("gbtree", "gblinear", "dart")),
       makeUntypedLearnerParam(id = "watchlist", default = NULL, tunable = FALSE),
       makeNumericLearnerParam(id = "eta", default = 0.3, lower = 0, upper = 1),
@@ -29,7 +27,6 @@ makeRLearner.regr.xgboost.custom = function() {
       makeNumericLearnerParam(id = "tweedie_variance_power", lower = 1, upper = 2, default = 1.5, requires = quote(objective == "reg:tweedie")),
       makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE),
       makeIntegerLearnerParam(id = "nrounds", default = 1L, lower = 1L),
-      # FIXME nrounds seems to have no default in xgboost(), if it has 1, par.vals is redundant
       makeUntypedLearnerParam(id = "feval", default = NULL, tunable = FALSE),
       makeIntegerLearnerParam(id = "verbose", default = 1L, lower = 0L, upper = 2L, tunable = FALSE),
       makeIntegerLearnerParam(id = "print_every_n", default = 1L, lower = 1L, tunable = FALSE,

--- a/R/RLearner_regr_xgboost.earlystop.R
+++ b/R/RLearner_regr_xgboost.earlystop.R
@@ -22,7 +22,17 @@ makeRLearner.regr.xgboost.earlystop = function() {
       makeIntegerLearnerParam(id = "max.nrounds", default = 10^6L, lower = 1L, upper = 10^7L),
       makeUntypedLearnerParam(id = "early.stopping.data"),
       makeLogicalLearnerParam(id = "maximize", default = NULL, special.vals = list(NULL), tunable = FALSE),
-      makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE)
+      makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE),
+      makeDiscreteLearnerParam(id = "booster", default = "gbtree", values = c("gbtree", "gblinear", "dart")),
+      makeDiscreteLearnerParam(id = "sample_type", default = "uniform", values = c("uniform", "weighted"), requires = quote(booster == "dart")),
+      makeDiscreteLearnerParam(id = "normalize_type", default = "tree", values = c("tree", "forest"), requires = quote(booster == "dart")),
+      makeNumericLearnerParam(id = "rate_drop", default = 0, lower = 0, upper = 1, requires = quote(booster == "dart")),
+      makeNumericLearnerParam(id = "skip_drop", default = 0, lower = 0, upper = 1, requires = quote(booster == "dart")),
+      makeLogicalLearnerParam(id = "one_drop", default = FALSE, requires = quote(booster == "dart")),
+      makeDiscreteLearnerParam(id = "tree_method", default = "exact", values = c("exact", "hist"), requires = quote(booster != "gblinear")),
+      makeDiscreteLearnerParam(id = "grow_policy", default = "depthwise", values = c("depthwise", "lossguide"), requires = quote(tree_method == "hist")),
+      makeIntegerLearnerParam(id = "max_leaves", default = 0L, lower = 0L, requires = quote(grow_policy == "lossguide")),
+      makeIntegerLearnerParam(id = "max_bin", default = 256L, lower = 2L, requires = quote(tree_method == "hist"))
     ),
     properties = c("numerics", "weights", "missings"),
     name = "eXtreme Gradient Boosting",

--- a/R/RLearner_regr_xgboost.earlystop.R
+++ b/R/RLearner_regr_xgboost.earlystop.R
@@ -21,6 +21,7 @@ makeRLearner.regr.xgboost.earlystop = function() {
       makeIntegerLearnerParam(id = "early_stopping_rounds", default = 1, lower = 1L, tunable = FALSE),
       makeIntegerLearnerParam(id = "max.nrounds", default = 10^6L, lower = 1L, upper = 10^7L),
       makeUntypedLearnerParam(id = "early.stopping.data"),
+      makeLogicalLearnerParam(id = "maximize", default = NULL, special.vals = list(NULL), tunable = FALSE),
       makeIntegerLearnerParam(id = "nthread", lower = 1L, tunable = FALSE)
     ),
     properties = c("numerics", "weights", "missings"),

--- a/R/autoxgboost.R
+++ b/R/autoxgboost.R
@@ -157,6 +157,7 @@ autoxgboost = function(task, measure = NULL, control = NULL, iterations = 160L, 
 
   opt = smoof::makeSingleObjectiveFunction(name = "optimizeWrapper",
     fn = function(x) {
+      x = x[!vlapply(x, is.na)]
       lrn = setHyperPars(base.learner, par.vals = x)
       mod = train(lrn, task.train)
       pred = predict(mod, task.test)

--- a/R/autoxgboost.R
+++ b/R/autoxgboost.R
@@ -113,7 +113,7 @@ autoxgboost = function(task, measure = NULL, control = NULL, iterations = 160L, 
     }
 
     base.learner = makeLearner("classif.xgboost.earlystop", id = "classif.xgboost.earlystop", predict.type = predict.type,
-      eval_metric = eval_metric, objective = objective, early_stopping_rounds = early.stopping.rounds,
+      eval_metric = eval_metric, objective = objective, early_stopping_rounds = early.stopping.rounds, maximize = !measure$minimize,
       max.nrounds = max.nrounds, par.vals = pv)
 
   } else if (tt == "regr") {
@@ -122,7 +122,7 @@ autoxgboost = function(task, measure = NULL, control = NULL, iterations = 160L, 
     eval_metric = "rmse"
 
     base.learner = makeLearner("regr.xgboost.earlystop", id = "regr.xgboost.earlystop",
-      eval_metric = eval_metric, objective = objective, early_stopping_rounds = early.stopping.rounds,
+      eval_metric = eval_metric, objective = objective, early_stopping_rounds = early.stopping.rounds, maximize = !measure$minimize,
       max.nrounds = max.nrounds, par.vals = pv)
 
   } else {

--- a/R/autoxgbparset.R
+++ b/R/autoxgbparset.R
@@ -29,3 +29,23 @@ autoxgbparset = makeParamSet(
   makeNumericParam("alpha", lower = -10, upper = 10, trafo = function(x) 2^x),
   makeNumericParam("subsample", lower = 0.5, upper = 1)
 )
+
+autoxgbparset.mixed = makeParamSet(
+  makeDiscreteParam("booster", values = c("gbtree", "gblinear", "dart")),
+  makeDiscreteParam("sample_type", values = c("uniform", "weighted"), requires = quote(booster == "dart")),
+  makeDiscreteParam("normalize_type", values = c("tree", "forest"), requires = quote(booster == "dart")),
+  makeNumericParam("rate_drop", lower = 0, upper = 1, requires = quote(booster == "dart")),
+  makeNumericParam("skip_drop", lower = 0, upper = 1, requires = quote(booster == "dart")),
+  makeLogicalParam("one_drop", requires = quote(booster == "dart")),
+  makeDiscreteParam("grow_policy", values = c("depthwise", "lossguide")),
+  makeIntegerParam("max_leaves", lower = 0, upper = 8, trafo = function(x) 2^x, requires = quote(grow_policy == "lossguide")),
+  makeIntegerParam("max_bin", lower = 2L, upper = 9, trafo = function(x) 2^x),
+  makeNumericParam("eta", lower = 0.01, upper = 0.2),
+  makeNumericParam("gamma", lower = -7, upper = 6, trafo = function(x) 2^x),
+  makeIntegerParam("max_depth", lower = 3, upper = 20),
+  makeNumericParam("colsample_bytree", lower = 0.5, upper = 1),
+  makeNumericParam("colsample_bylevel", lower = 0.5, upper = 1),
+  makeNumericParam("lambda", lower = -10, upper = 10, trafo = function(x) 2^x),
+  makeNumericParam("alpha", lower = -10, upper = 10, trafo = function(x) 2^x),
+  makeNumericParam("subsample", lower = 0.5, upper = 1)
+)

--- a/R/buildFinalLearner.R
+++ b/R/buildFinalLearner.R
@@ -3,7 +3,7 @@ buildFinalLearner = function(optim.result, objective, predict.type = NULL, par.s
 
   nrounds = getBestNrounds(optim.result)
   pars = trafoValue(par.set, optim.result$x)
-
+  pars = pars[!vlapply(pars, is.na)]
   lrn = if (!is.null(predict.type)) {
     makeLearner("classif.xgboost.custom", nrounds = nrounds, objective = objective,
       predict.type = predict.type, predict.threshold = getThreshold(optim.result))


### PR DESCRIPTION
This adds a second larger parameterset.

Tune over dart, linear learners and trees.
Uses a random forest instead of GP surrogate since the space is now mixed and hierachical