### PR TITLE
fix if dummycolname already exists as feature

### DIFF
--- a/R/generateCatFeatPipeline.R
+++ b/R/generateCatFeatPipeline.R
@@ -19,7 +19,7 @@ generateCatFeatPipeline = function(task, impact.encoding.boundary) {
   dummy.cols = setdiff(feat.cols, impact.cols)
 
   if (length(dummy.cols) > 0L)
-      cat.pipeline %<>>% cpoDummyEncode(affect.names = dummy.cols)
+      cat.pipeline %<>>% cpoDummyEncode(affect.names = dummy.cols, infixdot = TRUE)
   if (length(impact.cols) > 0L) {
     if (getTaskType(task) == "classif") {
       cat.pipeline %<>>% cpoImpactEncodeClassif(affect.names = impact.cols)


### PR DESCRIPTION
e.g. A1 with lvl 0 --> A10, which breaks is feature A10 already exists
set `infixdot = TRUE` within `cpoDummyEncode` leads to: A1 with lvl 0 --> A1.0